### PR TITLE
Remove createJSModules override

### DIFF
--- a/android/src/main/java/io/github/douglasjunior/ReactNativeEasyBluetooth/classic/ClassicPackage.java
+++ b/android/src/main/java/io/github/douglasjunior/ReactNativeEasyBluetooth/classic/ClassicPackage.java
@@ -47,7 +47,7 @@ public class ClassicPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated in RN 0.47 - facebook/react-native@ce6fb33
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 introduces a breaking change to createJSModules:
https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

This commit upgrades as advised in the commit message of ce6fb33.